### PR TITLE
Export2html

### DIFF
--- a/src/lineprofilergui/gui.py
+++ b/src/lineprofilergui/gui.py
@@ -65,6 +65,8 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.actionShowOutput.setIcon(ICONS["INFO"])
         self.actionLoadLprof = QtGui.QAction(self)
         self.actionLoadLprof.setIcon(ICONS["READFILE"])
+        self.actionSave = QtGui.QAction(self)
+        self.actionSave.setIcon(ICONS["SAVEFILE"])
         self.actionQuit = QtGui.QAction(self)
         self.actionQuit.setIcon(ICONS["ABORT"])
         self.actionConfigure = QtGui.QAction(self)
@@ -93,6 +95,7 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.menuProfiling.addAction(self.actionShowOutput)
         self.menuProfiling.addSeparator()
         self.menuProfiling.addAction(self.actionLoadLprof)
+        self.menuProfiling.addAction(self.actionSave)
         self.menuProfiling.addSeparator()
         self.menuProfiling.addAction(self.actionQuit)
         self.menubar.addAction(self.menuProfiling.menuAction())
@@ -164,6 +167,7 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.actionAbort.triggered.connect(self.kernprof_run.kill)
         self.actionShowOutput.toggled.connect(self.dockOutputWidget.setVisible)
         self.actionLoadLprof.triggered.connect(self.selectLprof)
+        self.actionSave.triggered.connect(self.saveLProfile)
         self.actionQuit.triggered.connect(QtWidgets.QApplication.instance().quit)
         self.actionLine_profiler_documentation.triggered.connect(
             lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl(LINE_PROFILER_DOC_URL))
@@ -197,6 +201,8 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.actionShowOutput.setShortcut(_("F7"))
         self.actionLoadLprof.setText(_("&Load data..."))
         self.actionLoadLprof.setShortcut(_("Ctrl+O"))
+        self.actionSave.setText(_("&Save profile..."))
+        self.actionSave.setShortcut(_("Ctrl+S"))
         self.actionQuit.setText(_("&Quit"))
         self.actionQuit.setShortcut(_("Ctrl+Q"))
         self.actionConfigure.setText(_("&Configuration..."))
@@ -248,6 +254,18 @@ class UIMainWindow(QtWidgets.QMainWindow):
         )
         if filename:
             self.load_lprof(filename)
+
+    def saveLProfile(self):
+        filename, _selfilter = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            _("Save line profiler data"),
+            "",
+            _("HTML") + " (*.html);; " + _("All files") + " (*.*)",
+        )
+        if filename:
+            html = self.resultsTreeWidget.generate_html()
+            with open(filename, "w") as f:
+                f.write(html)
 
     @QtCore.Slot()
     def configure(self):

--- a/src/lineprofilergui/gui.py
+++ b/src/lineprofilergui/gui.py
@@ -65,8 +65,8 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.actionShowOutput.setIcon(ICONS["INFO"])
         self.actionLoadLprof = QtGui.QAction(self)
         self.actionLoadLprof.setIcon(ICONS["READFILE"])
-        self.actionSave = QtGui.QAction(self)
-        self.actionSave.setIcon(ICONS["SAVEFILE"])
+        self.actionExport = QtGui.QAction(self)
+        self.actionExport.setIcon(ICONS["EXPORT2HTML"])
         self.actionQuit = QtGui.QAction(self)
         self.actionQuit.setIcon(ICONS["ABORT"])
         self.actionConfigure = QtGui.QAction(self)
@@ -95,7 +95,7 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.menuProfiling.addAction(self.actionShowOutput)
         self.menuProfiling.addSeparator()
         self.menuProfiling.addAction(self.actionLoadLprof)
-        self.menuProfiling.addAction(self.actionSave)
+        self.menuProfiling.addAction(self.actionExport)
         self.menuProfiling.addSeparator()
         self.menuProfiling.addAction(self.actionQuit)
         self.menubar.addAction(self.menuProfiling.menuAction())
@@ -167,7 +167,7 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.actionAbort.triggered.connect(self.kernprof_run.kill)
         self.actionShowOutput.toggled.connect(self.dockOutputWidget.setVisible)
         self.actionLoadLprof.triggered.connect(self.selectLprof)
-        self.actionSave.triggered.connect(self.saveLProfile)
+        self.actionExport.triggered.connect(self.exportLProfile)
         self.actionQuit.triggered.connect(QtWidgets.QApplication.instance().quit)
         self.actionLine_profiler_documentation.triggered.connect(
             lambda: QtGui.QDesktopServices.openUrl(QtCore.QUrl(LINE_PROFILER_DOC_URL))
@@ -201,8 +201,8 @@ class UIMainWindow(QtWidgets.QMainWindow):
         self.actionShowOutput.setShortcut(_("F7"))
         self.actionLoadLprof.setText(_("&Load data..."))
         self.actionLoadLprof.setShortcut(_("Ctrl+O"))
-        self.actionSave.setText(_("&Save profile..."))
-        self.actionSave.setShortcut(_("Ctrl+S"))
+        self.actionExport.setText(_("&Export as HTML..."))
+        self.actionExport.setShortcut(_("Ctrl+E"))
         self.actionQuit.setText(_("&Quit"))
         self.actionQuit.setShortcut(_("Ctrl+Q"))
         self.actionConfigure.setText(_("&Configuration..."))
@@ -255,10 +255,10 @@ class UIMainWindow(QtWidgets.QMainWindow):
         if filename:
             self.load_lprof(filename)
 
-    def saveLProfile(self):
+    def exportLProfile(self):
         filename, _selfilter = QtWidgets.QFileDialog.getSaveFileName(
             self,
-            _("Save line profiler data"),
+            _("Export line profiler data as HTML"),
             "",
             _("HTML") + " (*.html);; " + _("All files") + " (*.*)",
         )

--- a/src/lineprofilergui/tree.py
+++ b/src/lineprofilergui/tree.py
@@ -312,6 +312,56 @@ class ResultsTreeWidget(QtWidgets.QTreeWidget):
                 col, not settings.value(f"column{col+1}Visible", True, bool)
             )
 
+    def generate_html(self):
+        def get_text_color(item):
+            color = item.foreground(0).color()
+            return color.name()
+
+        def get_background_color(item: QtWidgets.QTreeWidgetItem):
+            color = item.background(0).color().name(QtGui.QColor.HexArgb)
+            return color[0] + color[3:] + color[1:3]  # Swap alpha and color
+
+        html = "<html><head><style>"
+        html += "ul {list-style-type: none;}"
+        html += (
+            "body {background-color: #282A36; color: #F8F8F2; font-family: monospace;}"
+        )
+        html += "li {margin: 5px 0;}"
+        html += "</style></head><body>"
+
+        for i in range(self.topLevelItemCount()):
+            top_item = self.topLevelItem(i)
+            html += '<ul class="tree">'
+            html += "<li>"
+            html += "<details open>"
+            html += f"<summary>{top_item.text(0)}</summary>"
+            html += "<table>"
+            html += "<tr>"
+            for col in range(self.columnCount()):
+                if not self.isColumnHidden(col):
+                    html += f"<th>{self.headerItem().text(col)}</th>"
+            html += "</tr>"
+            for j in range(top_item.childCount()):
+                child = top_item.child(j)
+                bg_color = get_background_color(child)
+                if bg_color == "#000000ff":
+                    bg_color = "#282A36ff"
+                text_color = get_text_color(child)
+                if text_color == "#000000":
+                    text_color = "#F8F8F2"
+                html += "<tr>"
+                for col in range(self.columnCount()):
+                    if not self.isColumnHidden(col):
+                        html += f'<td style="background-color:{bg_color}; color:{text_color}; white-space: pre;">{child.text(col)}</td>'
+                html += "</tr>"
+            html += "</table>"
+            html += "</details>"
+            html += "</li>"
+            html += "</ul>"
+
+        html += "</body></html>"
+        return html
+
     @QtCore.Slot(QtWidgets.QTreeWidgetItem)
     def item_activated(self, item):
         # Skip parent lines

--- a/src/lineprofilergui/tree.py
+++ b/src/lineprofilergui/tree.py
@@ -313,7 +313,7 @@ class ResultsTreeWidget(QtWidgets.QTreeWidget):
             )
 
     def generate_html(self):
-        def get_text_color(item):
+        def get_text_color(item: QtWidgets.QTreeWidgetItem):
             color = item.foreground(0).color()
             return color.name()
 

--- a/src/lineprofilergui/utils.py
+++ b/src/lineprofilergui/utils.py
@@ -19,6 +19,7 @@ _ICON_IDS = {
     "SETTINGS": QtWidgets.QStyle.SP_FileDialogListView,  # actionSettings
     "BLANKFILE": QtWidgets.QStyle.SP_FileIcon,  # statsButton
     "READFILE": QtWidgets.QStyle.SP_FileDialogContentsView,  # scriptButton, kernprofButton
+    "SAVEFILE": QtWidgets.QStyle.SP_DialogSaveButton,  # scriptButton, kernprofButton
     "DIRECTORY": QtWidgets.QStyle.SP_DirIcon,  # wdirButton
     "EXPAND": QtWidgets.QStyle.SP_ToolBarVerticalExtensionButton,  # actionExpand_all
     "COLLAPSE": QtWidgets.QStyle.SP_ToolBarHorizontalExtensionButton,  # actionCollapse_all

--- a/src/lineprofilergui/utils.py
+++ b/src/lineprofilergui/utils.py
@@ -19,7 +19,7 @@ _ICON_IDS = {
     "SETTINGS": QtWidgets.QStyle.SP_FileDialogListView,  # actionSettings
     "BLANKFILE": QtWidgets.QStyle.SP_FileIcon,  # statsButton
     "READFILE": QtWidgets.QStyle.SP_FileDialogContentsView,  # scriptButton, kernprofButton
-    "SAVEFILE": QtWidgets.QStyle.SP_DialogSaveButton,  # scriptButton, kernprofButton
+    "EXPORT2HTML": QtWidgets.QStyle.SP_DialogSaveButton,  # scriptButton, kernprofButton
     "DIRECTORY": QtWidgets.QStyle.SP_DirIcon,  # wdirButton
     "EXPAND": QtWidgets.QStyle.SP_ToolBarVerticalExtensionButton,  # actionExpand_all
     "COLLAPSE": QtWidgets.QStyle.SP_ToolBarHorizontalExtensionButton,  # actionCollapse_all


### PR DESCRIPTION
This pull request adds a new feature to export line profiler results as an HTML file from the GUI. The most important changes are grouped below:

**New Export Feature:**

* Added a new `Export as HTML...` action (`actionExport`) to the GUI, including an icon, menu entry, and keyboard shortcut (`Ctrl+E`). [[1]](diffhunk://#diff-326813a541f2c206dbb78dbdb3a01ff483d57ce883881ed74229c0827240f26cR68-R69) [[2]](diffhunk://#diff-326813a541f2c206dbb78dbdb3a01ff483d57ce883881ed74229c0827240f26cR98) [[3]](diffhunk://#diff-326813a541f2c206dbb78dbdb3a01ff483d57ce883881ed74229c0827240f26cR204-R205) [[4]](diffhunk://#diff-719577b9fed54749f6173a56fef277d36c11f70b595afbbdf9cd12861273e463R22)
* Connected the new export action to a handler method (`exportLProfile`), which opens a file dialog and saves the profiler results as HTML. [[1]](diffhunk://#diff-326813a541f2c206dbb78dbdb3a01ff483d57ce883881ed74229c0827240f26cR170) [[2]](diffhunk://#diff-326813a541f2c206dbb78dbdb3a01ff483d57ce883881ed74229c0827240f26cR258-R269)

**HTML Export Implementation:**

* Implemented a `generate_html` method in `resultsTreeWidget` that generates a styled HTML representation of the profiling results, preserving colors and formatting.